### PR TITLE
feat: add Docker Compose support for frontend development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,29 @@ Here, the technologies and structures used for the backend are described.
 ```bash
 git clone https://github.com/Turing-Activities-by-Pareto/pareto-back.git
 cd backend
-npm install  # or pip install -r requirements.txt
 ```
 
-### Running the Server
+### Push the newest app to the Docker Hub
 
 ```bash
-npm start  # or python app.py
+DOCKER_PASSWORD=PASSWORD DOCKER_USERNAME=mr3iscuit ./gradlew clean build jib 
+```
+
+### Running the Backend in local environment
+
+```bash
+docker compose up
+```
+
+### Stop all of the services
+
+```bash
+docker compose down
 ```
 
 ### API Endpoints
 
-| Method | URL         | Description               |
-|--------|------------|---------------------------|
-| GET    | /activities | Checks the server status |
-
-
-### Contact
-If you have any questions, please feel free to contact us.
+#### Default Swagger URL
+```bash
+http://localhost:8080/swagger-ui/index.html
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,21 @@ services:
       - "16543:80"
     depends_on:
       - postgres-compose
+
+  java-app:
+    image: mr3iscuit/activities:latest
+    container_name: activities_backend
+    ports:
+        - "8080:8080"
+    depends_on:
+        - postgres-compose
+        - minio
+    pull_policy: always
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-compose:5432/activities
+      - SPRING_DATASOURCE_USERNAME=user
+      - SPRING_DATASOURCE_PASSWORD=12345678
+      - MINIO_URL=http://minio:9000
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,10 +16,10 @@ spring:
     show-sql: true
 
 minio:
-  url: http://localhost:9000
+  url: ${MINIO_URL}
   presignedUrlExpiry: 5
   default-buckets: event-background, category-icon, sub-category-icon
   access:
-    name: "minioadmin"
-    secret: "minioadmin"
+    name: ${MINIO_ACCESS_KEY}
+    secret: ${MINIO_SECRET_KEY}
     chunkSize: 10485760


### PR DESCRIPTION
- Updated `docker-compose.yml` to include `java-app` service for backend
- Configured environment variables for MinIO and PostgreSQL in `docker-compose.yml`
- Updated `application.yml` to use environment variables for MinIO configuration
- Modified `README.md` with instructions for running the backend via Docker Compose
- Added steps for pushing the latest backend image to Docker Hub